### PR TITLE
[messages] refs #25 - Fields for signing large transactions

### DIFF
--- a/protob/messages/messages.proto
+++ b/protob/messages/messages.proto
@@ -462,4 +462,6 @@ message TransactionSign {
 	repeated SkycoinTransactionInput transactionIn = 2;
 	required uint32 nbOut = 3;
 	repeated SkycoinTransactionOutput transactionOut = 4;
+  // This field will be present ONLY for transactions with more than 8 inputs or 8 outputs
+  optional bool noMoreTransactionData = 5;
 }


### PR DESCRIPTION

Fixes #25 

Changes:
- Add `noMoreTransactionData` bool flag in `TransactionSign` message specs

Does this change need to mentioned in CHANGELOG.md?

No
