### PR TITLE
Import path for protobuf in go ref #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add env var `GO_PREFIX_IMPORT_PATH` to set up the import path from a parent go project.
+- Customize go import path using env var `GO_IMPORT`. Useful when project is a subfolder of a parent go project.
 - Generate protobuffer classes for go lang with `gogofast` plugin for `protoc`
 - Generate protobuffer classes for Javascript with `pbjs`
 - Generate protobuffer classes for C and Python with `nanopb` and Python plugin for `protoc`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add env var `GO_PREFIX_IMPORT_PATH` to set up the import path from a parent go project.
 - Generate protobuffer classes for go lang with `gogofast` plugin for `protoc`
 - Generate protobuffer classes for Javascript with `pbjs`
 - Generate protobuffer classes for C and Python with `nanopb` and Python plugin for `protoc`

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(OUT_GO)/%.pb.go: $(PROTOB_MSG_DIR)/%.proto
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto/ -I protob/messages --gogofast_out=$(OUT_GO) $<
 
 clean-go:
-	rm $$( find $(OUT_GO) -name '*.pb.go' )
+	rm -rf $$( find $(OUT_GO) -name '*.pb.go' )
 
 #----------------
 # Javascript

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ PROTOB_PY_DIR = py
 PROTOB_C_DIR  = c
 PROTOB_SRC_DIR  = $(GOPATH)/src/$(PROTOC_GOGO_URL)
 
+GO_PREFIX_IMPORT_PATH ?= github.com\/skycoin\/hardware-wallet-go\/src\/device-wallet/messages
+
 PROTOB_MSG_FILES = $(shell ls -1 $(PROTOB_MSG_DIR)/*.proto)
 PROTOB_MSG_SPECS = $(patsubst %,$(PROTOB_MSG_DIR)/%,$(notdir $(PROTOB_MSG_FILES)))
 PROTOB_MSG_GO    = $(patsubst %,$(PROTOB_GO_DIR)/%,$(notdir $(PROTOB_MSG_FILES:.proto=.pb.go)))
@@ -93,7 +95,7 @@ build-go: install-deps-go $(PROTOB_MSG_GO) $(OUT_GO)/google/protobuf/descriptor.
 
 $(OUT_GO)/google/protobuf/descriptor.pb.go:
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto --gogofast_out=$(OUT_GO) $(PROTOC_NANOPBGEN_DIR)/proto/google/protobuf/descriptor.proto
-	sed $(SED_FLAGS) 's/import\ protobuf\ \"google\/protobuf\"/import\ protobuf\ \"github\.com\/google\/protobuf\"/g' $(OUT_GO)/types.pb.go
+	sed $(SED_FLAGS) 's/import\ protobuf\ \"google\/protobuf\"/import\ protobuf\ \"$(GO_PREFIX_IMPORT_PATH)\/go\/google\/protobuf\"/g' $(OUT_GO)/types.pb.go
 
 $(OUT_GO)/%.pb.go: $(PROTOB_MSG_DIR)/%.proto
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto/ -I protob/messages --gogofast_out=$(OUT_GO) $<

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PROTOB_PY_DIR = py
 PROTOB_C_DIR  = c
 PROTOB_SRC_DIR  = $(GOPATH)/src/$(PROTOC_GOGO_URL)
 
-GO_PREFIX_IMPORT_PATH ?= github.com\/skycoin\/hardware-wallet-go\/src\/device-wallet/messages
+GO_PREFIX_IMPORT_PATH ?= github.com\/skycoin\/hardware-wallet-go\/src\/device-wallet\/messages
 
 PROTOB_MSG_FILES = $(shell ls -1 $(PROTOB_MSG_DIR)/*.proto)
 PROTOB_MSG_SPECS = $(patsubst %,$(PROTOB_MSG_DIR)/%,$(notdir $(PROTOB_MSG_FILES)))

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ PROTOB_PY_DIR = py
 PROTOB_C_DIR  = c
 PROTOB_SRC_DIR  = $(GOPATH)/src/$(PROTOC_GOGO_URL)
 
-GO_PREFIX_IMPORT_PATH ?= github.com\/skycoin\/hardware-wallet-go\/src\/device-wallet\/messages
+# Use default value when including this repository in vendor/ with dep
+# Set it explicitly either when generating to acustom location 
+# or when this repository is included at a subpath other than vendor
+# e.g. go library should set this to github.com/skycoin/hardware-wallet-go/src/device-wallet/messages
+GO_IMPORT ?= github.com/skycoin/hardware-wallet-protob
+GO_IMPORT_SED = $(shell echo $(GO_IMPORT) | sed 's/\//\\\//g')
 
 PROTOB_MSG_FILES = $(shell ls -1 $(PROTOB_MSG_DIR)/*.proto)
 PROTOB_MSG_SPECS = $(patsubst %,$(PROTOB_MSG_DIR)/%,$(notdir $(PROTOB_MSG_FILES)))
@@ -95,7 +100,7 @@ build-go: install-deps-go $(PROTOB_MSG_GO) $(OUT_GO)/google/protobuf/descriptor.
 
 $(OUT_GO)/google/protobuf/descriptor.pb.go:
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto --gogofast_out=$(OUT_GO) $(PROTOC_NANOPBGEN_DIR)/proto/google/protobuf/descriptor.proto
-	sed $(SED_FLAGS) 's/import\ protobuf\ \"google\/protobuf\"/import\ protobuf\ \"$(GO_PREFIX_IMPORT_PATH)\/go\/google\/protobuf\"/g' $(OUT_GO)/types.pb.go
+	sed $(SED_FLAGS) 's/import\ protobuf\ \"google\/protobuf\"/import\ protobuf\ \"$(GO_IMPORT_SED)\/go\/google\/protobuf\"/g' $(OUT_GO)/types.pb.go
 
 $(OUT_GO)/%.pb.go: $(PROTOB_MSG_DIR)/%.proto
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto/ -I protob/messages --gogofast_out=$(OUT_GO) $<

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ build-py                       Generate protobuf classes for Python with nanopb
 
 Code generation commands (i.e. `build-*` targets) can generate source code at any location should the following variables be properly set:
 
-- `OUT_C` env var allows to output protobuf C code onto a custom directory 
-- `OUT_GO` env var allows to output protobuf go code onto a custom directory 
-- `OUT_JS` env var allows to output protobuf js code onto a custom directory 
-- `OUT_PY` env var allows to output protobuf Python code onto a custom directory 
+- `OUT_C` env var allows to output protobuf C code onto a custom directory
+- `OUT_GO` env var allows to output protobuf go code onto a custom directory
+- `OUT_JS` env var allows to output protobuf js code onto a custom directory
+- `OUT_PY` env var allows to output protobuf Python code onto a custom directory
+
+- When using this projets as submodule of a go project foo.bar/my/project consider using the env var `GO_PREFIX_IMPORT_PATH` to `foo.bar/my/project/path/where/this/project/live/as/submodule`.
 
 ## Development setup
 


### PR DESCRIPTION
Fixes #29

Changes:
- Add a env variable (`GO_IMPORT_PATH`) to specify parent project impot path for golang.

Does this change need to mentioned in CHANGELOG.md?

Yes

