### PR TITLE
[messages] fixes #42 - Disambiguation in ApplySettings serialization

### DIFF
--- a/protob/messages/messages.proto
+++ b/protob/messages/messages.proto
@@ -116,8 +116,8 @@ message Features {
  */
 message ApplySettings {
     optional string language = 1;
-    optional string label = 2;
-    optional bool use_passphrase = 3;
+    optional bool use_passphrase = 2;
+    optional string label = 3;
     optional bytes homescreen = 4;
 }
 


### PR DESCRIPTION
Fixes #42 

Changes:
- usePassphrase is the delimiter between `label` and `language`

Does this change need to mentioned in CHANGELOG.md?

No

