### PR TITLE
force `$(OUT_GO)/types.pb.go` to be generated before apply the patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ install-deps-go: install-protoc ## Install tools to generate protobuf classes fo
 
 build-go: install-deps-go $(PROTOB_MSG_GO) $(OUT_GO)/google/protobuf/descriptor.pb.go ## Generate protobuf classes for go lang
 
-$(OUT_GO)/google/protobuf/descriptor.pb.go:
+$(OUT_GO)/google/protobuf/descriptor.pb.go: $(OUT_GO)/types.pb.go
 	protoc -I./$(PROTOC_NANOPBGEN_DIR)/proto --gogofast_out=$(OUT_GO) $(PROTOC_NANOPBGEN_DIR)/proto/google/protobuf/descriptor.proto
 	sed $(SED_FLAGS) 's/import\ protobuf\ \"google\/protobuf\"/import\ protobuf\ \"$(GO_IMPORT_SED)\/go\/google\/protobuf\"/g' $(OUT_GO)/types.pb.go
 


### PR DESCRIPTION
Fixes #44

Changes:
- make the rule `$(OUT_GO)/google/protobuf/descriptor.pb.go`(that apply the patch) depends on `$(OUT_GO)/types.pb.go`

Does this change need to mentioned in CHANGELOG.md?
No

