### PR TITLE
[messages] fixes #57 - Add Failure_FirmwarePanic to FailureType enum

### DIFF
--- a/protob/messages/types.proto
+++ b/protob/messages/types.proto
@@ -44,6 +44,7 @@ enum FailureType {
 	Failure_NotInitialized = 11;
 	Failure_PinMismatch = 12;
 	Failure_AddressGeneration = 13;
+	Failure_FirmwarePanic = 14;
 	Failure_FirmwareError = 99;
 }
 


### PR DESCRIPTION
Fixes #57 

Changes:
- Add `Failure_FirmwarePanic` in `FailureType` enum type.

Does this change need to mentioned in CHANGELOG.md?

Yes

Related issues:

PR skycoin/hardware-wallet#290 for issue skycoin/hardware-wallet#266

